### PR TITLE
No need to pass scene around for updates

### DIFF
--- a/src/scripts/objects/fpsText.js
+++ b/src/scripts/objects/fpsText.js
@@ -5,7 +5,7 @@ export default class FpsText extends Phaser.GameObjects.Text {
     this.setOrigin(0)
   }
 
-  update(scene) {
-    this.setText(`fps: ${Math.floor(scene.game.loop.actualFps)}`)
+  update() {
+    this.setText(`fps: ${Math.floor(this.scene.game.loop.actualFps)}`)
   }
 }


### PR DESCRIPTION
Removed the scene argument for the update() as GameObjects get a scene property for free.